### PR TITLE
Windows imports backslashes to forward slashes

### DIFF
--- a/src/index/syncFileSystem.ts
+++ b/src/index/syncFileSystem.ts
@@ -11,6 +11,10 @@ const makeImportPath = (p1: string, p2: string) => {
     path.basename(fullPath, ext === ".json" ? undefined : ext)
   );
 
+  if (process.platform === "win32") {
+    newImport = newImport.replace(/\\/g, "/");
+  }
+
   if (!newImport.startsWith(".")) {
     newImport = "./" + newImport;
   }


### PR DESCRIPTION
The imports on window are made with backslashes instead of forward slashes.

By the way, other than that it works great on windows 10