### PR TITLE
Using regex to replace the import slashes

### DIFF
--- a/src/index/syncFileSystem.ts
+++ b/src/index/syncFileSystem.ts
@@ -16,9 +16,11 @@ const makeImportPath = (p1: string, p2: string, useForwardSlashes: boolean) => {
   }
 
   if (useForwardSlashes) {
-    newImport = newImport.replace("\\", "/");
+    // Replace \ with /
+    newImport = newImport.replace(/\\/g, "/");
   } else {
-    newImport = newImport.replace("/", "\\");
+    // Replace / and \ with \\
+    newImport = newImport.replace(/\/|\\+/g, "\\\\");
   }
 
   return newImport;


### PR DESCRIPTION
Problem:
Using .replace() with a string at the first parameter only replaces the first instance.

Solution:
Using .replace() with a regex as the first parameter gives the option to replace all instances.

Extra:
The backslash import needs two backslashes because the first escapes the second