### PR TITLE
regex like, for root command's path

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "commander": "^4.1.1",
     "fs-extra": "^8.1.0",
+    "glob": "^7.1.6",
     "simple-git": "^1.131.0"
   },
   "jest": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ cli
 
     glob(path, (err, files) => {
       if (err || !files.length) {
-        console.log("Not able able to resolve the given path.");
+        console.log("Not able to resolve the given path.");
         console.error(err);
         process.exit(1);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { existsSync } from "fs";
 import commander from "commander";
+import glob from "glob";
 import { formatFileStructure } from "./index/formatFileStructure";
 
 export const cli = new commander.Command();
@@ -10,15 +10,20 @@ cli
   .name("butler")
   .description("Prettier for File Structures")
   .arguments("<path>")
-  .action(async start => {
-    if (start === "help") return;
+  .action(path => {
+    if (path === "help") return;
 
-    if (!existsSync(start)) {
-      console.log("path does not exist: ", start);
-      process.exit(1);
-    }
+    glob(path, (err, files) => {
+      if (err || !files.length) {
+        console.log("Not able able to resolve the given path.");
+        console.error(err);
+        process.exit(1);
+      }
 
-    await formatFileStructure(start);
+      files.forEach(async file => {
+        await formatFileStructure(file);
+      });
+    });
   })
   // keep at the end
   .parse(process.argv);


### PR DESCRIPTION
Using Glob to resolve paths as described in #20 

Commands like `butler-cli src/*` are now possible.
See [Glob's api for more](https://www.npmjs.com/package/glob).