### PR TITLE
fix: use rc files

### DIFF
--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "lint-staged"
+  }
+}

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,4 @@
+{
+  "*.{js,ts}": ["prettier --write", "eslint --fix"],
+  "*.{json,md,yaml}": ["prettier --write"]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testPathIgnorePatterns: ["/tests/fixtures/", "/test/tmp/"],
+  coveragePathIgnorePatterns: ["/tests/tmp/"],
+};

--- a/package.json
+++ b/package.json
@@ -42,23 +42,5 @@
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
     "simple-git": "^1.131.0"
-  },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/tests/fixtures/",
-      "/test/tmp/"
-    ],
-    "coveragePathIgnorePatterns": [
-      "/tests/tmp/"
-    ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "*.{ts}": "prettier --write",
-    "*.ts": "eslint --cache --fix"
   }
 }


### PR DESCRIPTION
This removes dependency settings from `package.json` and moves it into
seperate rc files. It also includes `json`, `md` and `yaml` files when
running the `pre-commit` hook.